### PR TITLE
don't let job tile break out of container

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -255,6 +255,7 @@ label {
 
 .restName {
   color: black;
+  word-break: break-word;
 }
 
 .busca {

--- a/public/styles.css
+++ b/public/styles.css
@@ -266,6 +266,7 @@ label {
   font-size: 45px;
   color: black;
   font-weight: 900;
+  word-break: break-word;
 }
 
 .switch {


### PR DESCRIPTION
Fixes #9 

Prevent job titles  from spilling out of container and causing layout probems else where

### Before 
<img width="388" alt="Screenshot 2019-06-12 at 20 18 07" src="https://user-images.githubusercontent.com/4013283/59376008-9bf57b80-8d4f-11e9-88c9-8d5ce8711c8e.png">

### After
<img width="387" alt="Screenshot 2019-06-12 at 20 17 57" src="https://user-images.githubusercontent.com/4013283/59376017-a0219900-8d4f-11e9-8152-e43441067974.png">

